### PR TITLE
Added functionality to load scripts on post type archive pages.

### DIFF
--- a/lib/class.dependencies.php
+++ b/lib/class.dependencies.php
@@ -5,11 +5,21 @@ class AECDependencies {
 		//called from wp_print_scripts action
 		public static function add_post_scripts() {
 			global $aecomments;
-			if (is_single()) {
-				AECDependencies::add_scripts();
-			} elseif (is_page() && $aecomments->get_admin_option( 'show_pages' ) == 'true') {
-				AECDependencies::add_scripts();
-			} elseif ( is_admin() && $aecomments->get_user_option( 'admin_editing' ) == 'false' ) {
+			if (
+				is_single() ||
+				(
+					is_page() &&
+					$aecomments->get_admin_option( 'show_pages' ) == 'true'
+				) ||
+				(
+					is_admin() &&
+					$aecomments->get_user_option( 'admin_editing' ) == 'false'
+				) ||
+				(
+					$aecomments->get_admin_option( 'scripts_on_archive' ) == 'true' &&
+					is_post_type_archive($aecomments->get_admin_option( 'allowed_archives' ))
+				)
+			) {
 				AECDependencies::add_scripts();
 			}
 		} //end add_post_scripts
@@ -40,7 +50,14 @@ class AECDependencies {
 		public static function add_css(){
 			global $aecomments;
 			
-			if (is_single() || is_page() || is_admin()) {
+			if ( is_single() ||
+				is_page() ||
+				is_admin() ||
+				(
+					$aecomments->get_admin_option( 'scripts_on_archive' ) == 'true' &&
+					is_post_type_archive($aecomments->get_admin_option( 'allowed_archives' ))
+				)
+			) {
 				if (is_page() && $aecomments->get_admin_option( 'show_pages' ) != 'true') 
 					return;
 
@@ -162,8 +179,15 @@ if ( typeof( ajaxurl ) == 'undefined' ) { var ajaxurl = '<?php echo esc_js( admi
 			if ($aecomments->get_admin_option( 'compressed_scripts' ) == 'true') {
 				$min = ".min";
 			}
+
 			if ($skiptest == true) {
-				if (!is_page() && !is_single())
+				if (!is_page() && 
+					!is_single() &&
+					(
+						$aecomments->get_admin_option( 'scripts_on_archive' ) != 'true' ||
+						!is_post_type_archive($aecomments->get_admin_option( 'allowed_archives' ))
+					)
+				)
 					return;
 				if ('closed' == $post->comment_status && !is_user_logged_in()) 
 					return;
@@ -189,7 +213,13 @@ if ( typeof( ajaxurl ) == 'undefined' ) { var ajaxurl = '<?php echo esc_js( admi
 			global $aecomments, $post;
 			if (is_admin()) { return; }
 			
-			if (!is_page() && !is_single())
+			if (!is_page() && 
+				!is_single() &&
+				(
+					$aecomments->get_admin_option( 'scripts_on_archive' ) != 'true' ||
+					!is_post_type_archive($aecomments->get_admin_option( 'allowed_archives' ))
+				)
+			)
 					return;
 			if ('closed' == $post->comment_status && !is_user_logged_in()) 
 					return;

--- a/lib/class.utility.php
+++ b/lib/class.utility.php
@@ -124,5 +124,26 @@ class AECUtility {
 			} //end for
 			return $pass;
 		} //end random
+
+		/**
+		 * Wrapper for get_post_types with preset arguments to get all default post types
+		 * @param  array 	$args 		An array of key value arguments to match against the post types	
+		 * @param  string 	$output 	The type of output to return, either 'names' or 'objects'
+		 * @param  string 	$operator 	Operator (and/or) to use with multiple $args
+		 * @return array
+		 */
+		public static function get_post_types($args = [], $output = "names", $operator = 'and') {
+			$default_args = [
+				'public'   => true,
+				'_builtin' => true,
+			];
+
+			$args = array_merge($default_args, $args);
+
+			$output = 'names'; // names or objects, note names is the default
+			$operator = 'and'; // 'and' or 'or'
+
+			return get_post_types( $args, $output, $operator );
+		}
 } 
 ?>

--- a/views/admin-panel/behavior.php
+++ b/views/admin-panel/behavior.php
@@ -4,6 +4,7 @@ if ( !is_a( $aecomments, 'WPrapAjaxEditComments' ) && !current_user_can( 'admini
 	die('');
 
 $options = $aecomments->get_all_admin_options(); //global settings
+$all_post_types = $aecomments->get_all_post_types(); //post types array
 
 //Update settings
 $updated = false;
@@ -47,6 +48,8 @@ if (isset($_POST['update'])) {
 	$options['affiliate_text'] = apply_filters('pre_comment_content',apply_filters('comment_save_pre', $_POST['affiliate_text']));
 	$options['affiliate_show'] = $_POST['affiliate_show'];
 	$options['scripts_in_footer'] = $_POST['scripts_in_footer'];
+	$options['scripts_on_archive'] = $_POST['scripts_on_archive'];
+	$options['allowed_archives'] = $_POST['allowed_archives'];
 	$options['compressed_scripts'] = $_POST['compressed_scripts'];
 	$options['after_deadline_posts'] = $_POST['after_deadline_posts'];
 	$options['after_deadline_popups'] = $_POST['after_deadline_popups'];
@@ -179,10 +182,26 @@ if ($updated && !$error) {
   	<th scope="row"><?php _e('Performance','ajaxEdit'); ?></th>
     <td>
     <p><strong><?php _e('Load Scripts in Footer? (Requires WordPress 2.8 or above and theme compatibility)', 'ajaxEdit') ?></strong></p>
-    <p><label for="scripts_in_footer_yes"><input type="radio" id="scripts_in_footer_yes" name="scripts_in_footer" value="true" <?php if ($options['scripts_in_footer'] == "true") { echo('checked="checked"'); }?> /> <?php _e('Yes', 'ajaxEdit') ?></label>&nbsp;&nbsp;&nbsp;&nbsp;<label for="scripts_in_footer_no"><input type="radio" id="scripts_in_footer_no" name="scripts_in_footer" value="false" <?php if ($options['scripts_in_footer'] == "false") { echo('checked="checked"'); }?>/> <?php _e('No', 'ajaxEdit') ?></label></p>
+    <p><label for="scripts_in_footer_yes"><input type="radio" id="scripts_in_footer_yes" name="scripts_in_footer" value="true" <?php if ($options['scripts_in_footer'] == "true") { echo('checked="checked"'); }?> /> <?php _e('Yes', 'ajaxEdit') ?></label>&nbsp;&nbsp;&nbsp;&nbsp;<label for="scripts_in_footer_no"><input type="radio" id="scripts_in_footer_no" name="scripts_in_footer" value="false" <?php if ($options['scripts_in_footer'] == "false") { echo('checked="checked"'); }?>/> <?php _e('No', 'ajaxEdit') ?></label>
+    </p>
     <p><strong><?php _e('Use Compressed JavaScript Files?', 'ajaxEdit') ?></strong></p>
     <p><label for="compressed_scripts_yes"><input type="radio" id="compressed_scripts_yes" name="compressed_scripts" value="true" <?php if ($options['compressed_scripts'] == "true") { echo('checked="checked"'); }?> /> <?php _e('Yes', 'ajaxEdit') ?></label>&nbsp;&nbsp;&nbsp;&nbsp;<label for="compressed_scripts_no"><input type="radio" id="compressed_scripts_no" name="compressed_scripts" value="false" <?php if ($options['compressed_scripts'] == "false") { echo('checked="checked"'); }?>/> <?php _e('No', 'ajaxEdit') ?></label></p>     
     </td>
+  </tr>
+  <tr valign="top">
+  	<th scope="row"><?php _e('Archives','ajaxEdit'); ?></th>
+    <td>
+    <p><strong><?php _e('Load Scripts on archives?', 'ajaxEdit') ?></strong></p>
+    <p><?php _e('This option should only be used if you have commenting enabled in your theme for archive pages', 'ajaxEdit') ?></p>
+    <p><label for="scripts_on_archive_yes"><input type="radio" id="scripts_on_archive_yes" name="scripts_on_archive" value="true" <?php if ($options['scripts_on_archive'] == "true") { echo('checked="checked"'); }?> /> <?php _e('Yes', 'ajaxEdit') ?></label>&nbsp;&nbsp;&nbsp;&nbsp;<label for="scripts_on_archive_no"><input type="radio" id="scripts_on_archive_no" name="scripts_on_archive" value="false" <?php if ($options['scripts_on_archive'] == "false") { echo('checked="checked"'); }?>/> <?php _e('No', 'ajaxEdit') ?></label>
+    </p>
+    <p><strong><?php _e('Select post type archives?', 'ajaxEdit') ?></strong></p>
+    <p><?php _e('This option will only take effect if "Load on archives?" is enabled. (Hold ctrl to select multiple)', 'ajaxEdit') ?></p>
+    <select name="allowed_archives[]" multiple="true">
+        <?php foreach ($all_post_types as $post_type) : ?>
+            <option value="<?php echo $post_type; ?>" <?php if (in_array($post_type, $options['allowed_archives'])) { echo('selected="selected"'); }?>><?php echo ucfirst($post_type); ?></option>
+        <?php endforeach; ?>
+    </select>
   </tr>
   <tr valign="top">
   	<th scope="row"><?php _e('Character Encoding','ajaxEdit') ?></th>

--- a/wp-ajax-edit-comments.php
+++ b/wp-ajax-edit-comments.php
@@ -162,6 +162,8 @@ if ( ! class_exists( 'WPrapAjaxEditComments' ) ) {
 					'affiliate_text' => '',
 					'affiliate_show' => 'false',
 					'scripts_in_footer' => 'false',
+					'scripts_on_archive' => 'false',
+					'allowed_archives' => array(),
 					'compressed_scripts' => 'true',
 					'drop_down' => array(),
 					'classic' => array(),
@@ -380,7 +382,6 @@ if ( ! class_exists( 'WPrapAjaxEditComments' ) ) {
 	
 			$this->skip = false;
 			//css
-			
 			add_action("wp_print_styles", array('AECDependencies',"load_frontend_css"));
 			add_action("wp_print_styles", array('AECDependencies',"add_css"));
 			add_action('admin_print_styles', array('AECDependencies',"add_css")); 
@@ -481,6 +482,34 @@ if ( ! class_exists( 'WPrapAjaxEditComments' ) ) {
 			}
 		} //end save_admin_options
 		
+		/**
+		 * Wrapper for AECUtility::get_post_types(). Gets public default post types.
+		 * @return array
+		 */
+		public function get_default_post_types() {
+			return AECUtility::get_post_types();
+		}
+
+		/**
+		 * Wrapper for AECUtility::get_post_types(). Gets public custom post types.
+		 * @return array
+		 */
+		public function get_custom_post_types() {
+			return AECUtility::get_post_types([
+				'public' => true,
+				'_builtin' => false
+			]);
+		}
+
+		/**
+		 * Wrapper for AECUtility::get_all_post_types(). Gets all public post types.
+		 * @return array
+		 */
+		public function get_all_post_types() {
+			$built_in = $this->get_default_post_types();
+			$custom = $this->get_custom_post_types();
+			return array_merge($built_in, $custom);
+		}
     } //end class
 }
 //instantiate the class


### PR DESCRIPTION
- Added utilty method to get post types
- Added wrapper methods for the utility to fetch built in post types, custom post types and all post types
- Updated behaviour admin settings to control loading scripts on archive and which archives to load on
- Two new admin options control this: 'scripts_on_archive' and 'allowed_archives'